### PR TITLE
Catch exceptions that occure during notification. Fix #85

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='shifthelper',
-    version='0.6.1',
+    version='0.7.0',
     description='a tool for helping people with a FACT night shift',
     url='https://github.com/fact-project/shifthelper',
     author='Dominik Neise, Maximilian Noethe, Sebastian Mueller',

--- a/shifthelper/__main__.py
+++ b/shifthelper/__main__.py
@@ -98,7 +98,7 @@ def main():
         print(term.cyan('Twilio Phone Setup'))
 
     caller = Caller(
-        phone_number=args['<phone_number>'], 
+        phone_number=args['<phone_number>'],
         ring_time=20,
         sid=config.get('twilio', 'sid'),
         auth_token=config.get('twilio', 'auth_token'),

--- a/shifthelper/checks/__init__.py
+++ b/shifthelper/checks/__init__.py
@@ -115,15 +115,27 @@ class Alert(Thread):
     def run(self):
         while not self.stop_event.is_set():
             if len(self.queue) > 0:
-                if self.caller is not None:
-                    self.caller.place_call()
+
                 while len(self.queue) > 0:
                     message = self.queue.popleft()
                     self.logger.warning(message)
                     if self.messenger is not None:
-                        self.messenger.send_message(message)
+                        try:
+                            self.messenger.send_message(message)
+                        except:
+                            self.logger.exception('Could not send message')
                         if 'Source' in message:
                             with open(qla_filename, 'rb') as img:
-                                self.messenger.send_image(img)
+                                try:
+                                    self.messenger.send_image(img)
+                                except:
+                                    self.logger.exception('Could not send image')
+
+                if self.caller is not None:
+                    try:
+                        self.caller.place_call()
+                    except:
+                        self.logger.exception('Could not place call')
+                        self.queue.append('Could not place call')
 
             self.stop_event.wait(self.interval)


### PR DESCRIPTION
This fixes the error that the Alert Thread dies if an exception is raised during the `place_call` or `send_message` steps. This can happen if the shifter has no internet connection when an alert happens.

If an exception is raised, a new message is put into the queue so that as soon as internet is available again, the shifter is called.