### PR TITLE
Call fallback shifter if primary shifter has no phone number

### DIFF
--- a/shifthelper/notifiers.py
+++ b/shifthelper/notifiers.py
@@ -57,7 +57,9 @@ class FactTwilioNotifier(TwilioNotifier):
 
     def phone_number_of_normal_shifter(self):
         try:
-            return whoisonshift().phone_mobile
+            phone_number = whoisonshift().phone_mobile
+            if not phone_number:
+                return self.phone_number_of_fallback_shifter()
         except IndexError:
             return config['developer']['phone_number']
 

--- a/shifthelper/tools/whosonshift.py
+++ b/shifthelper/tools/whosonshift.py
@@ -9,7 +9,6 @@ import logging
 log = logging.getLogger(__name__)
 
 
-
 def whoisonshift(clear_cache=False):
     if clear_cache:
         retrieve_calendar_entries.cache_clear()


### PR DESCRIPTION
This will call the fallback shifter if the primary shifters phone number is empty.

This should not happen as shifters are supposed to test this before their first shift, but it did.