### PR TITLE
Fix fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM continuumio/miniconda3
 
-
+RUN apt update && apt install build-essential --yes
 
 RUN conda install \
 	pandas requests numpy matplotlib \
 	python-dateutil sqlalchemy PyMySQL \
-	docopt pytz numexpr scipy pymongo astropy 
+	docopt pytz numexpr scipy pymongo astropy \
+	&& conda clean --all --yes 
 
 RUN pip install twilio retrying wrapt \
 	simple-crypt python-json-logger telepot \

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'sqlalchemy',       # in anaconda
         'PyMySQL',          # in anaconda
         'pytz',             # in anaconda
-        'twilio',
+        'twilio==5.7.0',
         'numexpr',
         'smart_fact_crawler==0.3.0',
         'custos==0.0.7',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='shifthelper',
-    version='1.1.2',
+    version='1.1.3',
     description='a tool for helping people with a FACT night shift',
     url='https://github.com/fact-project/shifthelper',
     author='Dominik Neise, Maximilian Noethe, Sebastian Mueller',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='shifthelper',
-    version='1.1.3',
+    version='1.1.4',
     description='a tool for helping people with a FACT night shift',
     url='https://github.com/fact-project/shifthelper',
     author='Dominik Neise, Maximilian Noethe, Sebastian Mueller',

--- a/shifthelper/notifiers.py
+++ b/shifthelper/notifiers.py
@@ -29,8 +29,14 @@ class FactTwilioNotifier(TwilioNotifier):
         self.twiml = 'hangup'
 
     def notify(self, recipient, msg):
-        super().notify(recipient, msg)
-        self.not_acknowledged_calls.append((self.call, msg))
+        try:
+            super().notify(recipient, msg)
+            self.not_acknowledged_calls.append((self.call, msg))
+        except:
+            self.not_acknowledged_calls.append((None, msg))
+            log.exception(
+                'Could not notifiy recipient {}'.format(recipient)
+            )
 
     def _remove_acknowledged_and_old_calls(self):
         """ from the list of not acknowledged calls
@@ -75,14 +81,11 @@ class FactTwilioNotifier(TwilioNotifier):
             log.exception('Error getting phone number, calling developer')
             return self.phone_number_of_developer()
 
-
     def phone_number_of_fallback_shifter(self):
         return config['fallback_shifter']['phone_number']
 
-
     def phone_number_of_developer(self):
         return config['developer']['phone_number']
-
 
     def get_numbers_to_call(self, msg):
         numbers_to_call = []
@@ -101,7 +104,6 @@ class FactTwilioNotifier(TwilioNotifier):
 
         return numbers_to_call
 
-
     def handle_message(self, msg):
         self._remove_acknowledged_and_old_calls()
         log.debug('Got a message')
@@ -110,9 +112,5 @@ class FactTwilioNotifier(TwilioNotifier):
 
             numbers_to_call = self.get_numbers_to_call(msg)
             for phone_number in numbers_to_call:
-                try:
-                    log.info('Calling {}'.format(phone_number))
-                    self.notify(phone_number, msg)
-                except:
-                    log.exception(
-                        'Could not notifiy recipient {}'.format(phone_number))
+                log.info('Calling {}'.format(phone_number))
+                self.notify(phone_number, msg)

--- a/shifthelper/notifiers.py
+++ b/shifthelper/notifiers.py
@@ -50,13 +50,12 @@ class FactTwilioNotifier(TwilioNotifier):
                 self.not_acknowledged_calls.remove((call, msg))
             else:
                 try:
-                    alert = alerts[msg.uuid]
+                    alert = alerts[str(msg.uuid)]
                 except KeyError:
                     continue
 
                 if alert['acknowledged'] is True:
-                    while (call, msg) in self.not_acknowledged_calls:
-                        self.not_acknowledged_calls.remove((call, msg))
+                    self.not_acknowledged_calls.remove((call, msg))
 
     def _get_oldest_call_age(self):
         max_age = datetime.timedelta()

--- a/shifthelper/tools/__init__.py
+++ b/shifthelper/tools/__init__.py
@@ -48,7 +48,8 @@ def create_db_connection(db_config=None):
                     host=db_config['host'],
                     db=db_config['database'],
                     port=db_config.get('port', 3306)
-                )
+                ),
+                pool_recycle=3600,
             )
     return db_engines[frozenset(db_config.items())]
 

--- a/shifthelper/tools/is_shift.py
+++ b/shifthelper/tools/is_shift.py
@@ -1,12 +1,17 @@
 import pandas as pd
 from .. import tools
-from functools import lru_cache
 from datetime import datetime
 from retrying import retry
+from cachetools import TTLCache, cached
+from cachetools.keys import hashkey
 
 from ..debug_log_wrapper import log_call_and_result
 
-@lru_cache(1)
+
+@cached(
+    cache=TTLCache(1, ttl=5 * 60),
+    key=lambda db: hashkey(None)
+)
 def get_MeasurementType(db=None):
     if db is None:
         db = tools.create_db_connection(tools.config['cloned_db'])
@@ -94,7 +99,6 @@ def get_next_shutdown(current_time_rounded_to_seconds=None, db=None):
         # in case we cannot find the next shutdown,
         # we simply say the next shutdown is waaaay far in the future.
         return datetime.max
-
 
 
 def get_last_shutdown(current_time_rounded_to_seconds=None, db=None):

--- a/shifthelper/tools/shift.py
+++ b/shifthelper/tools/shift.py
@@ -1,9 +1,9 @@
 import pandas as pd
 from .. import tools
-from functools import lru_cache
 from datetime import datetime
 from datetime import timedelta
 from cachetools import TTLCache, cached
+from cachetools.keys import hashkey
 
 import logging
 
@@ -22,11 +22,7 @@ WHERE
 '''
 
 
-def get_current_shifter(clear_cache=False, db=None):
-    if clear_cache:
-        retrieve_calendar_entries.cache_clear()
-        retrieve_valid_usernames_from_logbook.cache_clear()
-
+def get_current_shifter(db=None):
     full_shifter_info = retrieve_shifters_from_calendar(db=db)
     only_interesting_stuff = full_shifter_info[
         ["phone_mobile", "telegram_id", "skype", "username", "email"]
@@ -57,7 +53,10 @@ def retrieve_shifters_from_calendar(
     return tonights_shifters
 
 
-@lru_cache(100)
+@cached(
+    cache=TTLCache(1, ttl=5 * 60),
+    key=lambda dt_date, db: hashkey(dt_date)
+)
 def retrieve_calendar_entries(dt_date, db=None):
     if db is None:
         db = tools.create_db_connection(tools.config['cloned_db'])
@@ -74,8 +73,10 @@ def retrieve_calendar_entries(dt_date, db=None):
         return pd.read_sql_query(query, conn)
 
 
-# cache user data only for ten minutes, so changes take effect eventually
-@cached(cache=TTLCache(1, ttl=10 * 60))
+@cached(
+    cache=TTLCache(1, ttl=5 * 60),
+    key=lambda db: hashkey(None)
+)
 def retrieve_valid_usernames_from_logbook(db=None):
     if db is None:
         db = tools.create_db_connection(tools.config['cloned_db'])


### PR DESCRIPTION
* We were doing an item lookup using an `uuid.uuid4` object, but the key was the hex represantation
* This lead to acknowledged calls not being removed and thus calling the fallback unnecessaringly

* Fallback was not called, in case calling the first shifter raised an exception