### PR TITLE
Fix 239

### DIFF
--- a/shifthelper/tools/is_shift.py
+++ b/shifthelper/tools/is_shift.py
@@ -3,11 +3,15 @@ from .. import tools
 from datetime import datetime
 from retrying import retry
 from cachetools import TTLCache, cached
+from cachetools.keys import hashkey
 
 from ..debug_log_wrapper import log_call_and_result
 
 
-@cached(cache=TTLCache(1, ttl=5 * 60))
+@cached(
+    cache=TTLCache(1, ttl=5 * 60),
+    key=lambda db: hashkey(None)
+)
 def get_MeasurementType(db=None):
     if db is None:
         db = tools.create_db_connection(tools.config['cloned_db'])

--- a/shifthelper/tools/is_shift.py
+++ b/shifthelper/tools/is_shift.py
@@ -1,12 +1,13 @@
 import pandas as pd
 from .. import tools
-from functools import lru_cache
 from datetime import datetime
 from retrying import retry
+from cachetools import TTLCache, cached
 
 from ..debug_log_wrapper import log_call_and_result
 
-@lru_cache(1)
+
+@cached(cache=TTLCache(1, ttl=5 * 60))
 def get_MeasurementType(db=None):
     if db is None:
         db = tools.create_db_connection(tools.config['cloned_db'])
@@ -94,7 +95,6 @@ def get_next_shutdown(current_time_rounded_to_seconds=None, db=None):
         # in case we cannot find the next shutdown,
         # we simply say the next shutdown is waaaay far in the future.
         return datetime.max
-
 
 
 def get_last_shutdown(current_time_rounded_to_seconds=None, db=None):

--- a/shifthelper/tools/shift.py
+++ b/shifthelper/tools/shift.py
@@ -3,6 +3,7 @@ from .. import tools
 from datetime import datetime
 from datetime import timedelta
 from cachetools import TTLCache, cached
+from cachetools.keys import hashkey
 
 import logging
 
@@ -52,7 +53,10 @@ def retrieve_shifters_from_calendar(
     return tonights_shifters
 
 
-@cached(cache=TTLCache(1, ttl=5 * 60))
+@cached(
+    cache=TTLCache(1, ttl=5 * 60),
+    key=lambda dt_date, db: hashkey(dt_date)
+)
 def retrieve_calendar_entries(dt_date, db=None):
     if db is None:
         db = tools.create_db_connection(tools.config['cloned_db'])
@@ -69,7 +73,10 @@ def retrieve_calendar_entries(dt_date, db=None):
         return pd.read_sql_query(query, conn)
 
 
-@cached(cache=TTLCache(1, ttl=5 * 60))
+@cached(
+    cache=TTLCache(1, ttl=5 * 60),
+    key=lambda db: hashkey(None)
+)
 def retrieve_valid_usernames_from_logbook(db=None):
     if db is None:
         db = tools.create_db_connection(tools.config['cloned_db'])


### PR DESCRIPTION
should fix #239 
uses TTLCache now everywhere, and cache ignores the `db` parameter now, using the `key` parameter of `chachetoools.cache` similar to what was explained here:
https://stackoverflow.com/a/32655449

In case `db` was the only parameter, I use `hashkey(None)` which is a legal call, but if it actually works, I have not tested locally. 

What to you think? @MaxNoe 
