### PR TITLE
Identical windlimit as in ASR

### DIFF
--- a/shifthelper/__main__.py
+++ b/shifthelper/__main__.py
@@ -103,19 +103,11 @@ def main():
                     category=CATEGORY_SHIFTER
                 ),
                 FactIntervalCheck(
-                    name='WindSpeedCheck',
+                    name='WindCheckLikeASR',
+                    interval=30,
                     checklist=[
                         conditions.is_shift_at_the_moment,
-                        conditions.is_high_windspeed,
-                        conditions.is_not_parked,
-                    ],
-                    category=CATEGORY_SHIFTER
-                ),
-                FactIntervalCheck(
-                    name='WindGustCheck',
-                    checklist=[
-                        conditions.is_shift_at_the_moment,
-                        conditions.is_high_windgusts,
+                        conditions.is_more_than_2_wind_gusts_in_last_20_min,
                         conditions.is_not_parked,
                     ],
                     category=CATEGORY_SHIFTER

--- a/shifthelper/conditions.py
+++ b/shifthelper/conditions.py
@@ -375,3 +375,28 @@ def is_trigger_rate_low_for_ten_minutes():
     ]
     df = pd.DataFrame(self.history)
     return not df.empty and (df.rate < 1).all()
+
+
+@log_call_and_result
+def is_more_than_2_wind_gusts_in_last_20_min():
+    '''is_more_than_2_wind_gusts_in_last_20_min'''
+    self = is_more_than_2_wind_gusts_in_last_20_min
+
+    if not hasattr(self, 'history'):
+        self.history = pd.DataFrame()
+
+    self.history = self.history.append(
+        [{
+            'timestamp': datetime.utcnow(),
+            'wind_gusts_over_limit': sfc.weather().wind_gusts.value >= 50,
+        }]
+    )
+    now = datetime.utcnow()
+    self.history = self.history[
+        (now - self.history.timestamp) < timedelta(minutes=20)
+    ]
+
+    return (
+        not self.history.empty and
+        self.history.wind_gusts_over_limit.sum() > 2
+    )

--- a/shifthelper/conditions.py
+++ b/shifthelper/conditions.py
@@ -397,7 +397,17 @@ def is_more_than_2_wind_gusts_in_last_20_min():
         (datetime.utcnow() - self.history.timestamp) < timedelta(minutes=25)
     ]
 
+    # prepare a piece of history, which is 20 minutes long,
+    # but 5 min in the past
+    df = self.history.set_index('timestamp')
+    df = df[
+        datetime.utcnow() - timedelta(minutes=25):
+        datetime.utcnow() - timedelta(minutes=5)
+    ]
+
+    # look at this 5min-delayed, 20min-long history to give ASR some time
+    # to react.
     return (
-        not self.history.empty and
-        self.history.wind_gusts_over_limit.sum() > 2
+        not df.empty and
+        df.wind_gusts_over_limit.sum() > 2
     )

--- a/shifthelper/conditions.py
+++ b/shifthelper/conditions.py
@@ -391,9 +391,10 @@ def is_more_than_2_wind_gusts_in_last_20_min():
             'wind_gusts_over_limit': sfc.weather().wind_gusts.value >= 50,
         }]
     )
-    now = datetime.utcnow()
+
+    # we throw away everything older than 20 min
     self.history = self.history[
-        (now - self.history.timestamp) < timedelta(minutes=20)
+        (datetime.utcnow() - self.history.timestamp) < timedelta(minutes=20)
     ]
 
     return (

--- a/shifthelper/conditions.py
+++ b/shifthelper/conditions.py
@@ -392,9 +392,9 @@ def is_more_than_2_wind_gusts_in_last_20_min():
         }]
     )
 
-    # we throw away everything older than 20 min
+    # we throw away everything older than 25 min
     self.history = self.history[
-        (datetime.utcnow() - self.history.timestamp) < timedelta(minutes=20)
+        (datetime.utcnow() - self.history.timestamp) < timedelta(minutes=25)
     ]
 
     return (


### PR DESCRIPTION
The automatic suspend and resume thing (ASR) applys a different wind-speed-alert-limit/strategy than the current version of the shifthelper(SH).

So it can (and will) happen, that the SH calls a shifter, since the SH-wind-speed-limit is exceeded, but the ASR thinks the weather is just perfect, since the ASR simply has a different understanding of what "just perfect" means.

In this PR, I add a wind speed check which should behave exactly as the strategy applied by the ASR. 
It needs a history, so I do it similarly to the trigger rate check. Basically faking a static variable in a Python function, which is really ugly .. sorry for that.

Ah... maybe I should explain the strategy the ASR uses for completeness here:

 * look at the `wind_gusts` only not the `wind_speed`.
 * consider a "history" of the last 20 minutes. 
 * if the number of `wind_gusts` > 50km/h is larger than 2, we want to stop observations.

So .. we do not want to be called, in the same moment, when the ASR is just about to suspend operation and park the telescope, we want to be called a bit later. So... Instead of looking at the last 20minutes, this condition is looking at a 20min long history, which is from 5min in the past. This way I hope to correctly delay the SH call by 5minutes.

Ah also, I decreased the interval to 30sec, so this check is executed as often as the ASR is running. Otherwise the definition of "two times above the threshold within (the last) 20min" would differ. 

